### PR TITLE
add docker compose depends_on for js

### DIFF
--- a/js/docker-compose.yml
+++ b/js/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     build: ./client
     networks:
       - demo
+    depends_on:
+      - js-server
     env_file:
       - .env
     environment:


### PR DESCRIPTION
cc @mwear 

When I run `docker-compose up` for the `js` containers, I get error:
```
Attaching to js-client, js-server
js-client    | send: ping
js-client    | events.js:298
js-client    |       throw er; // Unhandled 'error' event
js-client    |       ^
js-client    |
js-client    | Error: connect ECONNREFUSED 172.18.0.3:8080
js-client    |     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1137:16)
js-client    | Emitted 'error' event on ClientRequest instance at:
js-client    |     at ClientRequest.req.emit (/usr/src/client/node_modules/ls-trace/packages/datadog-plugin-http/src/client.js:101:21)
js-client    |     at Socket.socketErrorListener (_http_client.js:426:9)
js-client    |     at Socket.emit (events.js:321:20)
js-client    |     at emitErrorNT (internal/streams/destroy.js:92:8)
js-client    |     at emitErrorAndCloseNT (internal/streams/destroy.js:60:3)
js-client    |     at processTicksAndRejections (internal/process/task_queues.js:84:21) {
js-client    |   errno: 'ECONNREFUSED',
js-client    |   code: 'ECONNREFUSED',
js-client    |   syscall: 'connect',
js-client    |   address: '172.18.0.3',
js-client    |   port: 8080
js-client    | }
js-client exited with code 1
js-server    | Running on 8080
```

This PR will force the order of the containers that start so `js-server` is up first before `js-client` tries to connect. With changes in this PR, stuff works for me:
```
Attaching to js-server, js-client
js-server    | Running on 8080
js-client    | send: ping
js-client    | recv: pong
```

Reference: https://docs.docker.com/compose/compose-file/#depends_on