### PR TITLE
Do not include scheme in LIGHTSTEP_HOST

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -1,6 +1,7 @@
 # js examples
 
 ## Environment variables
+
 Export or add to a .env file
 
 ```bash
@@ -10,7 +11,7 @@ export LIGHTSTEP_ACCESS_TOKEN=<lightstep access token>
 optionally, set the lightstep host
 
 ```bash
-export LIGHTSTEP_HOST=https://ingest.staging.lightstep.com
+export LIGHTSTEP_HOST=ingest.staging.lightstep.com
 ```
 
 ## Start the client
@@ -21,9 +22,8 @@ docker-compose up
 
 ## Supported variables
 
-
-| Name | Required | Default |
-| ---- | -------- | ------- |
-|LIGHTSTEP_ACCESS_TOKEN| yes|
-|LIGHTSTEP_COMPONENT_NAME|yes|
-|LIGHTSTEP_HOST| No | ingest.lightstep.com|
+| Name                     | Required | Default              |
+| ------------------------ | -------- | -------------------- |
+| LIGHTSTEP_ACCESS_TOKEN   | yes      |
+| LIGHTSTEP_COMPONENT_NAME | yes      |
+| LIGHTSTEP_HOST           | No       | ingest.lightstep.com |

--- a/js/client/client.js
+++ b/js/client/client.js
@@ -4,9 +4,9 @@ const LIGHTSTEP_ACCESS_TOKEN = process.env.LIGHTSTEP_ACCESS_TOKEN;
 const COMPONENT_NAME =
   process.env.LIGHTSTEP_COMPONENT_NAME || 'ls-trace-js-client';
 const TARGET_URL = process.env.TARGET_URL || 'http://localhost:8080/ping';
-const LIGHTSTEP_HOST =
-  process.env.LIGHTSTEP_HOST || 'https://ingest.lightstep.com';
-const LIGHTSTEP_METRICS_URL = `${LIGHTSTEP_HOST}/metrics`;
+const LIGHTSTEP_HOST = process.env.LIGHTSTEP_HOST || 'ingest.lightstep.com';
+const LIGHTSTEP_URL = `https://${LIGHTSTEP_HOST}`;
+const LIGHTSTEP_METRICS_URL = `${LIGHTSTEP_URL}/metrics`;
 
 const tracer = require('ls-trace').init({
   experimental: {
@@ -16,7 +16,7 @@ const tracer = require('ls-trace').init({
   runtimeMetrics: true,
   reportingInterval: 30 * 1000,
   componentName: COMPONENT_NAME,
-  url: LIGHTSTEP_HOST,
+  url: LIGHTSTEP_URL,
   metricsUrl: LIGHTSTEP_METRICS_URL,
   tags: `lightstep.service_name:${COMPONENT_NAME},lightstep.access_token:${LIGHTSTEP_ACCESS_TOKEN}`,
 });

--- a/js/server/server.js
+++ b/js/server/server.js
@@ -4,9 +4,9 @@ const LIGHTSTEP_ACCESS_TOKEN = process.env.LIGHTSTEP_ACCESS_TOKEN;
 const COMPONENT_NAME =
   process.env.LIGHTSTEP_COMPONENT_NAME || 'ls-trace-js-server';
 const PORT = process.env.PORT || 8080;
-const LIGHTSTEP_HOST =
-  process.env.LIGHTSTEP_HOST || 'https://ingest.lightstep.com';
-const LIGHTSTEP_METRICS_URL = `${LIGHTSTEP_HOST}/metrics`;
+const LIGHTSTEP_HOST = process.env.LIGHTSTEP_HOST || 'ingest.lightstep.com';
+const LIGHTSTEP_URL = `https://${LIGHTSTEP_HOST}`;
+const LIGHTSTEP_METRICS_URL = `${LIGHTSTEP_URL}/metrics`;
 
 const express = require('express');
 const tracer = require('ls-trace').init({
@@ -17,7 +17,7 @@ const tracer = require('ls-trace').init({
   runtimeMetrics: true,
   reportingInterval: 30 * 1000,
   componentName: COMPONENT_NAME,
-  url: LIGHTSTEP_HOST,
+  url: LIGHTSTEP_URL,
   metricsUrl: LIGHTSTEP_METRICS_URL,
   tags: `lightstep.service_name:${COMPONENT_NAME},lightstep.access_token:${LIGHTSTEP_ACCESS_TOKEN}`,
 });


### PR DESCRIPTION
This PR fixes an issue where the JS examples previously included the scheme in the LIGHTSTEP_HOST.