### PR TITLE
Update js example with new config / latest source

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -5,13 +5,14 @@
 Export or add to a .env file
 
 ```bash
-export LIGHTSTEP_ACCESS_TOKEN=<lightstep access token>
+export SECRET_ACCESS_TOKEN=<lightstep access token>
+export DD_TRACE_AGENT_URL=https://ingest.lightstep.com
 ```
 
-optionally, set the lightstep host
+optionally, set the lightstep metrics url
 
 ```bash
-export LIGHTSTEP_HOST=ingest.staging.lightstep.com
+export LS_METRICS_URL=https://ingest.staging.lightstep.com/metrics
 ```
 
 ## Start the client
@@ -22,8 +23,9 @@ docker-compose up
 
 ## Supported variables
 
-| Name                     | Required | Default              |
-| ------------------------ | -------- | -------------------- |
-| LIGHTSTEP_ACCESS_TOKEN   | yes      |
-| LIGHTSTEP_COMPONENT_NAME | yes      |
-| LIGHTSTEP_HOST           | No       | ingest.lightstep.com |
+| Name                     | Required | Default                              |
+| ------------------------ | -------- | ------------------------------------ |
+| SECRET_ACCESS_TOKEN      | yes      |
+| LIGHTSTEP_COMPONENT_NAME | yes      |                                      |
+| DD_TRACE_AGENT_URL       | yes      |
+| LS_METRICS_URL           | No       | https://ingest.lightstep.com/metrics |

--- a/js/client/client.js
+++ b/js/client/client.js
@@ -1,24 +1,16 @@
 'use strict';
 
-const LIGHTSTEP_ACCESS_TOKEN = process.env.LIGHTSTEP_ACCESS_TOKEN;
+const ACCESS_TOKEN = process.env.SECRET_ACCESS_TOKEN;
 const COMPONENT_NAME =
   process.env.LIGHTSTEP_COMPONENT_NAME || 'ls-trace-js-client';
+const SERVICE_VERSION = process.env.LIGHTSTEP_SERVICE_VERSION || '0.0.1';
 const TARGET_URL = process.env.TARGET_URL || 'http://localhost:8080/ping';
-const LIGHTSTEP_HOST = process.env.LIGHTSTEP_HOST || 'ingest.lightstep.com';
-const LIGHTSTEP_URL = `https://${LIGHTSTEP_HOST}`;
-const LIGHTSTEP_METRICS_URL = `${LIGHTSTEP_URL}/metrics`;
 
 const tracer = require('ls-trace').init({
   experimental: {
     b3: true,
   },
-  clientToken: LIGHTSTEP_ACCESS_TOKEN,
-  runtimeMetrics: true,
-  reportingInterval: 30 * 1000,
-  componentName: COMPONENT_NAME,
-  url: LIGHTSTEP_URL,
-  metricsUrl: LIGHTSTEP_METRICS_URL,
-  tags: `lightstep.service_name:${COMPONENT_NAME},lightstep.access_token:${LIGHTSTEP_ACCESS_TOKEN}`,
+  tags: `lightstep.service_name:${COMPONENT_NAME},lightstep.access_token:${ACCESS_TOKEN},service.version:${SERVICE_VERSION}`,
 });
 const scope = tracer.scope();
 

--- a/js/client/package-lock.json
+++ b/js/client/package-lock.json
@@ -163,8 +163,8 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "ls-trace": {
-      "version": "github:lightstep/ls-trace-js#39cf1bd24b09b355802adcf4e65c5d277babc737",
-      "from": "github:lightstep/ls-trace-js#39cf1bd",
+      "version": "github:lightstep/ls-trace-js#9401f6bd380347be3a0a2e19610809ea6d714c24",
+      "from": "github:lightstep/ls-trace-js#9401f6b",
       "requires": {
         "@types/node": "^10.12.18",
         "container-info": "^1.0.1",
@@ -225,9 +225,9 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
       "requires": {
         "minimist": "^1.2.5"
       }

--- a/js/client/package.json
+++ b/js/client/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ls-trace": "github:lightstep/ls-trace-js#39cf1bd"
+    "ls-trace": "github:lightstep/ls-trace-js#9401f6b"
   }
 }

--- a/js/server/package-lock.json
+++ b/js/server/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "express_docker",
+  "name": "server",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -351,8 +351,8 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "ls-trace": {
-      "version": "github:lightstep/ls-trace-js#39cf1bd24b09b355802adcf4e65c5d277babc737",
-      "from": "github:lightstep/ls-trace-js#39cf1bd",
+      "version": "github:lightstep/ls-trace-js#9401f6bd380347be3a0a2e19610809ea6d714c24",
+      "from": "github:lightstep/ls-trace-js#9401f6b",
       "requires": {
         "@types/node": "^10.12.18",
         "container-info": "^1.0.1",
@@ -441,9 +441,9 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
       "requires": {
         "minimist": "^1.2.5"
       }

--- a/js/server/package.json
+++ b/js/server/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
-    "ls-trace": "github:lightstep/ls-trace-js#39cf1bd"
+    "ls-trace": "github:lightstep/ls-trace-js#9401f6b"
   }
 }

--- a/js/server/server.js
+++ b/js/server/server.js
@@ -1,25 +1,17 @@
 'use strict';
 
-const LIGHTSTEP_ACCESS_TOKEN = process.env.LIGHTSTEP_ACCESS_TOKEN;
+const PORT = process.env.PORT || 8080;
+const ACCESS_TOKEN = process.env.SECRET_ACCESS_TOKEN;
 const COMPONENT_NAME =
   process.env.LIGHTSTEP_COMPONENT_NAME || 'ls-trace-js-server';
-const PORT = process.env.PORT || 8080;
-const LIGHTSTEP_HOST = process.env.LIGHTSTEP_HOST || 'ingest.lightstep.com';
-const LIGHTSTEP_URL = `https://${LIGHTSTEP_HOST}`;
-const LIGHTSTEP_METRICS_URL = `${LIGHTSTEP_URL}/metrics`;
+const SERVICE_VERSION = process.env.LIGHTSTEP_SERVICE_VERSION || '0.0.1';
 
 const express = require('express');
 const tracer = require('ls-trace').init({
   experimental: {
     b3: true,
   },
-  clientToken: LIGHTSTEP_ACCESS_TOKEN,
-  runtimeMetrics: true,
-  reportingInterval: 30 * 1000,
-  componentName: COMPONENT_NAME,
-  url: LIGHTSTEP_URL,
-  metricsUrl: LIGHTSTEP_METRICS_URL,
-  tags: `lightstep.service_name:${COMPONENT_NAME},lightstep.access_token:${LIGHTSTEP_ACCESS_TOKEN}`,
+  tags: `lightstep.service_name:${COMPONENT_NAME},lightstep.access_token:${ACCESS_TOKEN},service.version:${SERVICE_VERSION}`,
 });
 
 const app = express();
@@ -32,4 +24,4 @@ app.get('/ping', (req, res) => {
 });
 
 app.listen(PORT);
-console.log(`Running on 8080`);
+console.log(`Running on ${PORT}`);


### PR DESCRIPTION
This updates the JS example to use the latest source and newly standardized configuration options. The example requires the following environment variables to be set: `SECRET_ACCESS_TOKEN`, `LIGHTSTEP_COMPONENT_NAME`, `DD_TRACE_AGENT_URL`. You can optionally set `LS_METRICS_URL` to staging, for example.