### PR TITLE
update collector config to export using otlp

### DIFF
--- a/collector/collector-config.yaml
+++ b/collector/collector-config.yaml
@@ -16,12 +16,17 @@ exporters:
     #   endpoint: satellite:8360
     #   secure: false
 
-    lightstep:
-        access_token: <TOKEN HERE>
-        satellite_host: "ingest.staging.lightstep.com"
-        satellite_port: 443
-        service_name: "myService"
-        plain_text: false
+    # configuring otlp to public satellites
+    otlp:
+      endpoint: ingest.lightstep.com:443
+      headers: {"lightstep-access-token":<TOKEN HERE>}
+
+    # lightstep:
+    #     access_token: <TOKEN HERE>
+    #     satellite_host: "ingest.lightstep.com"
+    #     satellite_port: 443
+    #     service_name: "myService"
+    #     plain_text: false
   
 processors:
     batch:
@@ -31,9 +36,8 @@ service:
     pipelines:
       traces:
         receivers: [opencensus, otlp]
-        # when a satellite with OTLP configured is available
-        # exporters: [logging, otlp]
         exporters: [logging, otlp]
+        # exporters: [logging, lightstep]
         processors: [batch]
       metrics:
         receivers: [opencensus, otlp]


### PR DESCRIPTION
Updating collector configuration to export using the otlp exporter. note this will only work once the fix for request headers has gone in.